### PR TITLE
feat: 로그인, 회원가입 api연결, redux-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "growup",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.1.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -16,8 +17,10 @@
         "react-calendar": "^4.8.0",
         "react-datepicker": "^4.25.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^9.1.0",
         "react-router-dom": "^6.21.2",
         "react-scripts": "^5.0.1",
+        "redux": "^5.0.1",
         "styled-component": "^2.8.0",
         "styled-components": "^6.1.8",
         "styled-reset": "^4.5.2",
@@ -3402,6 +3405,38 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.1.0.tgz",
+      "integrity": "sha512-nfJ/b4ZhzUevQ1ZPKjlDL6CMYxO4o7ZL7OSsvSOxzT/EN11LsBDgTqP7aedHtBrFSVoK7oTP1SbMWUwGb30NLg==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
@@ -4660,6 +4695,11 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -18697,6 +18737,32 @@
         "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -18962,6 +19028,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -19312,6 +19391,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -22675,6 +22759,14 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^2.1.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -11,8 +12,10 @@
     "react-calendar": "^4.8.0",
     "react-datepicker": "^4.25.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^9.1.0",
     "react-router-dom": "^6.21.2",
     "react-scripts": "^5.0.1",
+    "redux": "^5.0.1",
     "styled-component": "^2.8.0",
     "styled-components": "^6.1.8",
     "styled-reset": "^4.5.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import SignUpPage from "./pages/JoinPage/SignUpPage";
-import React from "react";
+import React, { useEffect } from "react";
 import { Outlet, Route, Routes } from "react-router-dom";
 import Header from "./components/common/Header";
 import MainPage from "./pages/MainPage/MainPage";
@@ -13,6 +13,11 @@ import ChangePasswordPage from "./pages/JoinPage/ChangePasswordPage";
 
 import MyPage from "./pages/MyPage/MyPage";
 import EditProfile from './pages/MyPage/EditProfile';
+import AuthApi from "./apis/Auth";
+import AxiosInstance from "./apis/CustomAxios";
+import { useDispatch } from "react-redux";
+import { login } from "./redux/user";
+import ProtectedRoute from "./pages/ProtectedRoute";
 
 function Layout() {
   return (
@@ -24,21 +29,43 @@ function Layout() {
 }
 
 function App() {
+  useEffect(() => {
+    onSilentRefresh();
+  }, []);
+
+  const dispatch = useDispatch();
+  const onSilentRefresh = async () => {
+    try {
+      const response = await AuthApi.silentRefresh();
+      console.log('silentRefresh success:', response);
+      AxiosInstance.defaults.headers.common["Authorization"] = `${response.result.newAccessToken}`;
+      console.log("로그인 연장")
+      dispatch(login({ isLogin: true }));
+    } catch (error) {
+      //console.error('silentRefresh failed:', error);
+      if (error.response?.status === 401) {
+        // refresh token 만료 - 로그인 페이지 이동
+        console.log('토큰만료 로그인페이지로')
+      }
+    }
+  };
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
         
         <Route index element={<MainPage />} />
         <Route path="/growroom" element={<GrowRoomPage />} />
-        <Route path="/growroom/write" element={<GrowRoomWritePage />} />
         <Route path="/growroom/:postId" element={<GrowRoomPostPage />} />
         <Route path="/liveup" element={<LiveUpPage />} />
         <Route path="/liveup/:roomid" element={<LiveUpJoinPage />} />
         <Route path="/signup" element={<SignUpPage />} />
-        <Route path="/mypage/edit" element={<EditProfile/>} />
-        <Route path="/mypage" element={<MyPage />} />
         <Route path="/findpassword" element={<FindPasswordPage />} />
         <Route path="/changepassword" element={<ChangePasswordPage />} /> 
+        <Route element={<ProtectedRoute />}>
+          <Route path="/growroom/write" element={<GrowRoomWritePage />} />
+          <Route path="/mypage/edit" element={<EditProfile/>} />
+          <Route path="/mypage" element={<MyPage />} />
+        </Route>
       </Route>
     </Routes>
   );

--- a/src/apis/Auth.jsx
+++ b/src/apis/Auth.jsx
@@ -1,9 +1,19 @@
+import { logout } from '../redux/user';
 import AxiosInstance from './CustomAxios';
 
 const AuthApi = {
   login: async (loginData) => {
     try {
-      const response = await AxiosInstance.post('/auth/login', loginData); //endpoint 맞추기
+      const response = await AxiosInstance.post('/growup/users/login', loginData); //endpoint 맞추기
+      console.log("response : ", response)
+      if (response && response.status === 200) {
+        AxiosInstance.defaults.headers.common[
+          "Authorization"
+        ] = `${response.data.result.accessToken}`;
+        //console.log("액세스 토큰 헤더에 저장", response.data.result.accessToken)
+        localStorage.setItem('refreshToken',response.data.result.refreshToken); //리프레시 토큰 저장
+        return response.data;
+      }
       return response.data;
     } catch (error) {
       console.error('Error in login:', error);
@@ -11,15 +21,58 @@ const AuthApi = {
     }
   },
 
+  logout: async () => {
+    try {
+      const response = await AxiosInstance.post('/growup/users/logout');
+      return response.data;
+    } catch (error) {
+      console.error('Error in logout:', error);
+      throw error;
+    }
+  },
+
   signUp: async (userData) => {
     try {
-      const response = await AxiosInstance.post('/auth/sign_up', userData);
+      const response = await AxiosInstance.post('/growup/users/signup', userData);
       return response.data;
     } catch (error) {
       console.error('Error in signUp:', error);
       throw error;
     }
   },
+
+  emailAuth: async(emailData) => { //가입 이메일인증
+    try {
+      const response = await AxiosInstance.post('/growup/users/auth', emailData);
+      return response.data;
+    } catch (error) {
+      console.error('Error in emailAuth:', error);
+      throw error;
+    }
+  },
+
+  findPasswordAuth: async(emailData) => { //비밀번호 찾기 이메일인증
+    try {
+      const response = await AxiosInstance.post('/growup/users/password-auth', emailData);
+      return response.data;
+    } catch (error) {
+      console.error('Error in findPasswordAuth:', error);
+      throw error;
+    }
+  },
+
+  silentRefresh: async() => {  // 토큰재발급
+    try {
+      const token = localStorage.getItem('refreshToken')
+      AxiosInstance.defaults.headers.common["Authorization"] = `${token}`;
+      const response = await AxiosInstance.post('/growup/users/token-reissue');
+      return response.data;
+    } catch (error) {
+      //console.error('Error in silentRefresh:', error);
+      throw error;
+    }
+  }
+
 //...
 };
 

--- a/src/apis/CustomAxios.jsx
+++ b/src/apis/CustomAxios.jsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const AxiosInstance = axios.create({
-  baseURL: "https://server_address", //기본 서버 주소
+  baseURL: "https://dev.jojoumc.shop", //기본 서버 주소
+  withCredentials: true,
   headers: {
     //토큰 부분 추가
   },

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -4,6 +4,10 @@ import styled from 'styled-components';
 import logo from './growupLogo.jpeg';
 import liveuplogo from './liveupLogo.jpeg';
 import LoginBox from './LoginBox';
+import { useDispatch, useSelector } from 'react-redux';
+import AuthApi from '../../apis/Auth';
+import { logout } from '../../redux/user';
+import { openLoginModal } from '../../redux/loginModal';
 
 const HeaderContainer = styled.div`
   position: fixed;
@@ -85,15 +89,25 @@ const Header = () => {
   const [activeLink, setActiveLink] = useState('');
   const location = useLocation();
   const [scrolled, setScrolled] = useState(false);
-  const [isLoginModalVisible, setIsLoginModalVisible] = useState(false);
+
+  const user = useSelector((state) => state.user.value)
+  const loginModal = useSelector((state) => state.loginModal.value)
+  const dispatch = useDispatch();
 
   const handleLoginClick = () => {
-    setIsLoginModalVisible(true);
+    dispatch(openLoginModal())
+    console.log("open")
   };
 
-  const handleCloseModal = () => {
-    setIsLoginModalVisible(false);
-  };
+  const handleLogout = async() =>{
+    try{
+      const response = await AuthApi.logout();
+      console.log('logout success: ', response);
+      dispatch(logout());
+    }catch(error){
+      console.log('logout failed: ', error);
+    }
+  }
 
   const handleScroll = () => {
     const offset = window.scrollY;
@@ -129,30 +143,39 @@ const Header = () => {
         <NavList liveup={isLiveUpPage}>
           {navItems.map((item) => (
             <NavItem key={item.id} active={activeLink === item.link || (item.link === '/' && activeLink === '')} liveup={isLiveUpPage}>
-            <Link
-              className={`header-nav-item ${activeLink === item.link ? 'active' : ''}`}
-              to={item.link}
-              onClick={() => handleLinkClick(item.link)}
-            >
-              {item.label}
-            </Link>
-          </NavItem>
+              <Link
+                className={`header-nav-item ${activeLink === item.link ? 'active' : ''}`}
+                to={item.link}
+                onClick={() => handleLinkClick(item.link)}
+              >
+                {item.label}
+              </Link>
+            </NavItem>
           ))}
         </NavList>
       </HeaderLeftWrap>
-      <RightList login signup={false} liveup={isLiveUpPage} onClick={handleLoginClick}>
+      {user.isLogin ? 
+      (<RightList login={true} onClick={handleLogout}>
         <AuthItem>
-            로그인
-        </AuthItem>
-      </RightList>
-      <Link to="/signup" style={{ textDecoration: 'none' }}>
-      <RightList signup>
-        <AuthItem>
-            회원가입
-        </AuthItem>
-      </RightList>
-      </Link>
-      {isLoginModalVisible && <LoginBox onClose={handleCloseModal} />}
+        로그아웃
+      </AuthItem>
+      </RightList>) :
+        (<>
+          <RightList login={true} signup={false} liveup={isLiveUpPage} onClick={handleLoginClick}>
+            <AuthItem>
+              로그인
+            </AuthItem>
+          </RightList>
+          <Link to="/signup" style={{ textDecoration: 'none' }}>
+            <RightList signup={true}>
+              <AuthItem>
+                회원가입
+              </AuthItem>
+            </RightList>
+          </Link>
+        </>)}
+      {loginModal.showLoginModal ? <LoginBox /> : <></>
+      }
     </HeaderContainer>
   );
 };

--- a/src/components/common/LoginBox.jsx
+++ b/src/components/common/LoginBox.jsx
@@ -5,6 +5,10 @@ import eye_green from '../../icon/eye_green.png'
 import logo from '../../icon/Logo.png'
 import x from '../../icon/cancel.png'
 import { Link } from 'react-router-dom'
+import AuthApi from '../../apis/Auth'
+import { useDispatch } from 'react-redux'
+import { login } from '../../redux/user'
+import { closeLoginModal } from '../../redux/loginModal'
 
 const LoginBackGround = styled.div`
   width: 100%;
@@ -139,7 +143,7 @@ const ErrorText = styled.span`
   font-weight: 500;
   line-height: 140%;
 `
-function LoginBox({ onClose }) {
+function LoginBox() {
   const [showPassword, setShowPassword] = useState(false);
 
   const [email, setEmail] = useState('');
@@ -150,6 +154,22 @@ function LoginBox({ onClose }) {
 
   const [emailTouched, setEmailTouched] = useState(false);
   const [passwordTouched, setPasswordTouched] = useState(false);
+
+  const dispatch = useDispatch();
+
+  const handleLogin = async (loginData) => {
+    try{
+      const response = await AuthApi.login(loginData);
+      console.log('login success: ', response);
+      dispatch(login({isLogin: true}));
+      dispatch(closeLoginModal()) //로그인 성공 후 로그인 창 끄기
+    } catch(error){
+      console.log('login failed: ', error);
+      if(error.response && error.response.data && error.response.data.message){
+        alert(error.response.data.message);
+      }
+    }
+  };
 
   const onChangeEmail = (e) => {
     setEmail(e.target.value);
@@ -167,7 +187,7 @@ function LoginBox({ onClose }) {
     setPassword(e.target.value);
     setPasswordTouched(true);
     // 비밀번호 유효성 검사
-    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/;
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,20}$/;
     if (!passwordRegex.test(e.target.value)) {
       setPasswordError(true);
     } else {
@@ -177,6 +197,11 @@ function LoginBox({ onClose }) {
 
   const onSubmit = async(e) => {
     e.preventDefault();
+    const loginData ={
+      email,
+      password
+    };
+    handleLogin(loginData)
   }
   return (
     <>
@@ -185,7 +210,7 @@ function LoginBox({ onClose }) {
         <LoginTopBar>
           <Logo src={logo} />
           <Xicon src={x} 
-          onClick={onClose}/>
+          onClick={() => dispatch(closeLoginModal())}/>
         </LoginTopBar>
         <LoginContainer>
           <LoginTitle>로그인</LoginTitle>
@@ -204,7 +229,7 @@ function LoginBox({ onClose }) {
             style={emailTouched && emailError ? {borderColor: '#FF4747'} : {borderColor: '#E7E7E7'}} />
             <LoginLabel htmlFor='password'>
               비밀번호
-              {passwordTouched && passwordError && <ErrorText>ⓘ 최소 8자, 최대 20자, 영문자, 숫자 모두 포함되어야 합니다.</ErrorText>}
+              {passwordTouched && passwordError && <ErrorText>ⓘ 최소 8자, 최대 20자, 영문자, 숫자, 특수문자(@$!%*?&) 모두 포함되어야 합니다.</ErrorText>}
               </LoginLabel>
             <PasswordContainer>
               <LoginInput id='password' 
@@ -220,11 +245,11 @@ function LoginBox({ onClose }) {
             disabled={emailError || passwordError} />
           </form>
           <Loginbottom>
-            <Link to='/findpassword' style={{ textDecoration: 'none' }} onClick={onClose}>
+            <Link to='/findpassword' style={{ textDecoration: 'none' }} onClick={() => dispatch(closeLoginModal())}>
               <span>비밀번호 찾기 </span>
             </Link>
             <span>| </span>
-            <Link to='/signup' style={{ textDecoration: 'none' }} onClick={onClose}>
+            <Link to='/signup' style={{ textDecoration: 'none' }} onClick={() => dispatch(closeLoginModal())}>
               <span>회원가입</span>
             </Link>
           </Loginbottom>

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,17 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import GlobalStyles from './GlobalStyles';
+import { Provider } from 'react-redux';
+import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
     <React.StrictMode>
-      <GlobalStyles/>
-      <App />
+      <Provider store={store}>
+        <GlobalStyles/>
+        <App />
+      </Provider>
     </React.StrictMode>
   </BrowserRouter>
 );

--- a/src/pages/JoinPage/FindPasswordPage.jsx
+++ b/src/pages/JoinPage/FindPasswordPage.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
+import AuthApi from '../../apis/Auth'
+import OverlayBox from '../../components/LiveUpPage/OverlayBox'
 
 const FindPasswordContainer = styled.div`
   margin-top: 180px;
@@ -87,6 +89,20 @@ function FindPasswordPage() {
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState(true);
   const [emailTouched, setEmailTouched] = useState(false);
+  const [mail, setMail] = useState(false); //메일발송확인 창
+
+  const handleAuth = async (emailData) => {
+    try{
+      const response = await AuthApi.findPasswordAuth(emailData);
+      console.log('findPasswordAuth success: ', response);
+      setMail(true)
+    } catch(error){
+      console.log('findPasswordAuth failed: ', error);
+      if(error.response && error.response.data && error.response.data.message){
+        alert(error.response.data.message);
+      }
+    }
+  };
 
   const onChangeEmail = (e) => {
     setEmail(e.target.value);
@@ -102,9 +118,19 @@ function FindPasswordPage() {
 
   const onSubmit = async(e) => {
     e.preventDefault();
+    const emailData ={
+      email
+    }
+    handleAuth(emailData);
   }
   return (
     <>
+    <OverlayBox
+        toggle={mail}
+        setToggle={setMail}
+        title={"메일이 발송 되었습니다!"}
+        subTitle={"닫기"}
+      />
     <FindPasswordContainer>
       <FindPasswordTitle>비밀번호 찾기</FindPasswordTitle>
       <FindPasswordText>

--- a/src/pages/JoinPage/SignUpPage.jsx
+++ b/src/pages/JoinPage/SignUpPage.jsx
@@ -4,6 +4,8 @@ import eye from '../../icon/eye.png'
 import eye_green from '../../icon/eye_green.png'
 import OverlayBox from '../../components/LiveUpPage/OverlayBox'
 import OverlayCheck from '../../components/LiveUpPage/OverlayCheck'
+import AuthApi from '../../apis/Auth'
+import { useNavigate } from 'react-router-dom'
 
 const SignUpcontainer = styled.div`
   margin-top: 302px;
@@ -113,6 +115,29 @@ const DoubleCheckBtn = styled.div`
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
   opacity: ${({ disabled }) => (disabled ? '0.5' : '1')};
 `
+
+const CompleteContainer = styled.div`
+  margin-top: 302px;
+  width: 500px;
+  height: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  margin-bottom: 200px;
+`
+const GotoMainBtn = styled.div`
+  border-radius: 5.333px;
+  background:#00D749;
+  width: 423px;
+  padding: 14px;
+  font-size: 25px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 140%;
+  color: white;
+  border: 0;
+  cursor: pointer;
+`
 function SignUpPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [showPasswordCheck, setShowPasswordCheck] = useState(false);
@@ -137,6 +162,36 @@ function SignUpPage() {
   const [passwordCheckTouched, setPasswordCheckTouched] = useState(false);
 
   const [doubleCheck, setDoubleCheck] = useState(false);
+
+  const navigate = useNavigate();
+  const [isEmailSent, setIsEmailSent] = useState(false);
+
+  const handleSignUp = async (userData) => {
+    try{
+      const response = await AuthApi.signUp(userData);
+      console.log('signUp success: ', response);
+      handleAuth({ email: userData.email });
+    } catch(error){
+      console.log('signUp failed: ', error);
+      if(error.response && error.response.data && error.response.data.message){
+        alert(error.response.data.message);
+      }
+    }
+  };
+  const handleAuth = async (emailData) => {
+    try{
+      const response = await AuthApi.emailAuth(emailData);
+      console.log('emailAuth success: ', response);
+      setIsEmailSent(true);
+    } catch(error){
+      console.log('emailAuth failed: ', error);
+      alert(error.response.data.message);
+    }
+  };
+
+  const handleMainPageNavigation = () => {
+    navigate('/');
+  };
 
   const onChangeName = (e) => {
     setName(e.target.value);
@@ -176,7 +231,7 @@ function SignUpPage() {
     setPassword(e.target.value);
     setPasswordTouched(true);
     // 비밀번호 유효성 검사
-    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/;
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,20}$/;
     if (!passwordRegex.test(e.target.value)) {
       setPasswordError(true);
     } else {
@@ -197,9 +252,32 @@ function SignUpPage() {
 
   const onSubmit = async(e) => {
     e.preventDefault();
+    const userData = {
+      name,
+      nickName: nickname,
+      email,
+      password,
+      passwordCheck
+    };
+    handleSignUp(userData);
   }
   return (
     <>
+    {isEmailSent ? ( //회원가입 완료창 (임시)
+        <CompleteContainer>
+          <div>
+            <div>임시 화면입니다.</div>
+            <div>입력하신 이메일 주소로 인증 메일을 보내드렸어요.</div>
+            <div>인증 메일을 확인해주세요✉️</div>
+          </div>
+          <div>
+            <div>반가워요. GROW UP🌱에 오신 것을 환영해요!</div>
+            <div>아직 한 단계가 더 남았어요!</div>
+            <div>가입하신 이메일을 인증해주시면, GROW UP🌱의 서비스를 이용하실 수 있습니다. 가입해주셔서 다시 한 번 감사드립니다🙇</div>
+          </div>
+          <GotoMainBtn onClick={handleMainPageNavigation}>메인 화면으로 이동</GotoMainBtn>
+        </CompleteContainer>
+      ): (
       <SignUpcontainer>
         {nickname === "쿼카" ? (
           <OverlayBox
@@ -251,7 +329,7 @@ function SignUpPage() {
             style={emailTouched && emailError ? { borderColor: '#FF4747' } : { borderColor: '#E7E7E7' }} />
           <SignUpLabel htmlFor='password'>
             비밀번호
-            {passwordTouched && passwordError && <ErrorText>ⓘ 최소 8자, 최대 20자, 영문자, 숫자 모두 포함되어야 합니다.</ErrorText>}
+            {passwordTouched && passwordError && <ErrorText>ⓘ 최소 8자, 최대 20자, 영문자, 숫자, 특수문자(@$!%*?&) 모두 포함되어야 합니다.</ErrorText>}
           </SignUpLabel>
           <PasswordContainer>
             <SignUpInput id='password'
@@ -282,6 +360,7 @@ function SignUpPage() {
             disabled={nameError || nicknameError || emailError || passwordError || passwordCheckError} />
         </form>
       </SignUpcontainer>
+      )}
     </>
   )
 }

--- a/src/pages/ProtectedRoute.jsx
+++ b/src/pages/ProtectedRoute.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Navigate, Outlet } from 'react-router-dom'
+import { closeLoginModal, openLoginModal } from '../redux/loginModal';
+
+function ProtectedRoute() {
+  const user = useSelector((state) => state.user.value)
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (user.isLogin) {
+      dispatch(closeLoginModal());
+    } else {
+      dispatch(openLoginModal());
+    }
+  }, [user, dispatch]);
+  return user.isLogin ? (
+    <Outlet />
+  ) : (
+    <Navigate to="/" />
+    
+  )
+}
+
+export default ProtectedRoute

--- a/src/redux/loginModal.js
+++ b/src/redux/loginModal.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const loginModalSlice = createSlice({
+  name: 'loginModal',
+  initialState: { value: { showLoginModal: false }},
+  reducers: {
+    openLoginModal: (state) => {
+      state.value = { showLoginModal: true };
+    },
+    closeLoginModal: (state) => {
+      state.value = { showLoginModal: false };
+    },
+  },
+});
+
+export const { openLoginModal, closeLoginModal } = loginModalSlice.actions;
+
+export default loginModalSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import userReducer from './user'
+import loginModalReducer from './loginModal';
+
+export default configureStore({
+  reducer: {
+    user: userReducer,
+    loginModal: loginModalReducer,
+  },
+})

--- a/src/redux/user.js
+++ b/src/redux/user.js
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const userSlice = createSlice({
+    name: "user",
+    initialState: { value: { isLogin: false }},
+    reducers: {
+        login: (state, action) => {
+            state.value = action.payload
+        },
+        logout: (state) => {
+            state.value = {isLogin: false}; // 초기 상태로 되돌립니다.
+        },
+    },
+});
+
+export const { login, logout } = userSlice.actions;
+export default userSlice.reducer;


### PR DESCRIPTION
<추가한 기능들>
로그인, 회원가입, 이메일인증, 비밀번호찾기 이메일인증,  토큰재발급, 로그아웃 api 연결
redux toolkit 추가
로그인 안한 상태시에는 헤더에  [로그인 , 회원가입버튼 ], 로그인 한 상태에서는 로그아웃버튼 뜨게함
로그인 안한 상태로 마이페이지, 글쓰기 페이지 못들어가도록 ProtectedRoute 추가
로그인 한 상태에서 새로고침해도 로그인 안풀리게 토큰 재발급